### PR TITLE
skip_before_action

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :configre_permitted_parameters, if: :devise_controller?
+  skip_before_action :verify_authenticity_token
 
   protected
   


### PR DESCRIPTION
## What
プロフィールを変更する際にトークンが合わなくなっていたのでスキップさせる
## Why
エラーになるため